### PR TITLE
Updates config with first discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ extends:
 
 This will make the config usable in any NPM script running the linter.
 
+### Environments
+
+You might need to set the `env` key as well depending on your project.
+
+```yaml
+env:
+  node: true
+  browser: true
+```
+
+If your project has multiple environments, multiple `.eslintrc.yml` files might be necessary.
+This could be the case for CDK and tests.
+
+#### CDK
+
+If your project uses CDK and is not otherwise a Node.js project, add a file `cdk/.eslintrc.yml`
+with the content
+
+```yaml
+env:
+  node: true
+```
+
 ## Development of the config
 
 While working on the shared config itself it is useful to work

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const WARN = 'warn'
 const ERROR = 'error'
 const NEVER = 'never'
 const ALWAYS = 'always'
+const OFF = 'off'
 
 const config = {
   root: true,
@@ -16,20 +17,23 @@ const config = {
   ],
   rules: {
     semi: [WARN, NEVER],
-    'jsx-quotes': [WARN, 'prefer-double'],
-    'comma-dangle': [WARN, 'always-multiline'],
+    'jsx-quotes': [WARN, 'prefer-single'],
     quotes: [WARN, 'single'],
 
     'max-len': [
-      WARN, 80, 2, {
+      WARN, 100, 2, {
         ignoreUrls: true,
         ignoreComments: false,
         ignoreRegExpLiterals: true,
         ignoreTemplateLiterals: true,
-        ignoreStrings: true,
-      },
+        ignoreStrings: true
+      }
     ],
     indent: [WARN, 2, { SwitchCase: 1, flatTernaryExpressions: true }],
+
+    // Empty blocks
+    'no-empty-function': OFF,
+    '@typescript-eslint/no-empty-function': OFF,
 
     // Spaces
     'func-call-spacing': [WARN, NEVER],
@@ -54,13 +58,16 @@ const config = {
     'one-var': [ERROR, NEVER],
     'no-whitespace-before-property': ERROR,
 
+    // Rules unneeded by us
+    'no-prototype-builtins': OFF,
+
     // Typescript specific
     '@typescript-eslint/naming-convention': [
       WARN,
       { selector: 'enum', format: ['PascalCase'] },
-      { selector: 'enumMember', format: ['UPPER_CASE'] },
-    ],
-  },
+      { selector: 'enumMember', format: ['UPPER_CASE'] }
+    ]
+  }
 }
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spielworksdev/eslint-config",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESlint rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changes the linting config with the results from the discussion on 11.10.2022.

The following decisions were made:

1. Line length up to 100.
2. Use single quotes everywhere, including JSX attributes.
3. Document environment settings that might need to be done per project
4. Trailing comma rule - disabled. Every project can choose what they like.
5. Disable the rules that disallow empty function bodies and using prototype builtins. We don't see value in them.

Also removes trailing commas as they are not required anymore.