### PR TITLE
Adds separate Javascript config

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 # Ignore everything except the README, index and package files
 *
 !index.js
+!javascript.js
 !package.json
 !package-lock.json
 !README.md

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ eslint):
 npm install --save-dev eslint @spielworksdev/eslint-config
 ```
 
-Then write a config file:
+Then write a config file (for Typescript projects):
 
 ```yaml
 # .eslintrc.yml
@@ -23,6 +23,14 @@ extends:
 ```
 
 This will make the config usable in any NPM script running the linter.
+
+If the project is a Javascript project, use
+
+```yaml
+# .eslintrc.yml
+extends:
+  - '@spielworksdev/eslint-config/javascript'
+```
 
 ### Environments
 

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
+// This is the config for Typescript projects. It's the default exported one as most of our
+// projects are Typescript.
+
 const WARN = 'warn'
-const ERROR = 'error'
-const NEVER = 'never'
-const ALWAYS = 'always'
 const OFF = 'off'
 
 const config = {
-  root: true,
   extends: [
-    'eslint:recommended',
+    // Extend the JavScript config as it still has valuable rules. Some rules might need to be
+    // duplicated in the TS plugin, though.
+    './javascript',
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
   ],
@@ -16,50 +17,9 @@ const config = {
     '@typescript-eslint',
   ],
   rules: {
-    semi: [WARN, NEVER],
-    'jsx-quotes': [WARN, 'prefer-single'],
-    quotes: [WARN, 'single'],
-
-    'max-len': [
-      WARN, 100, 2, {
-        ignoreUrls: true,
-        ignoreComments: false,
-        ignoreRegExpLiterals: true,
-        ignoreTemplateLiterals: true,
-        ignoreStrings: true
-      }
-    ],
-    indent: [WARN, 2, { SwitchCase: 1, flatTernaryExpressions: true }],
-
     // Empty blocks
-    'no-empty-function': OFF,
+    // Has to be repeated for Typescript
     '@typescript-eslint/no-empty-function': OFF,
-
-    // Spaces
-    'func-call-spacing': [WARN, NEVER],
-    'no-multi-spaces': WARN,
-    'arrow-spacing': WARN,
-    'comma-spacing': WARN,
-    'key-spacing': WARN,
-    'object-curly-spacing': [WARN, ALWAYS],
-    'no-trailing-spaces': WARN,
-    'block-spacing': WARN,
-
-    // Smells
-    'no-param-reassign': ERROR,
-    'no-eval': ERROR,
-    'no-extend-native': ERROR,
-    'no-duplicate-imports': ERROR,
-    'no-new-wrappers': ERROR,
-    'no-underscore-dangle': ERROR,
-    'no-var': ERROR,
-    'no-unreachable': ERROR,
-    'no-fallthrough': ERROR,
-    'one-var': [ERROR, NEVER],
-    'no-whitespace-before-property': ERROR,
-
-    // Rules unneeded by us
-    'no-prototype-builtins': OFF,
 
     // Typescript specific
     '@typescript-eslint/naming-convention': [

--- a/javascript.js
+++ b/javascript.js
@@ -1,0 +1,63 @@
+// This is the ESlint config for Javascript only projects
+
+const WARN = 'warn'
+const ERROR = 'error'
+const NEVER = 'never'
+const ALWAYS = 'always'
+const OFF = 'off'
+
+const config = {
+  extends: [
+    'eslint:recommended'
+  ],
+  env: {
+    es2022: true
+  },
+  rules: {
+    semi: [WARN, NEVER],
+    'jsx-quotes': [WARN, 'prefer-single'],
+    quotes: [WARN, 'single'],
+
+    'max-len': [
+      WARN, 100, 2, {
+        ignoreUrls: true,
+        ignoreComments: false,
+        ignoreRegExpLiterals: true,
+        ignoreTemplateLiterals: true,
+        ignoreStrings: true
+      }
+    ],
+    indent: [WARN, 2, { SwitchCase: 1, flatTernaryExpressions: true }],
+
+    // Empty blocks
+    'no-empty-function': OFF,
+
+    // Spaces
+    'func-call-spacing': [WARN, NEVER],
+    'no-multi-spaces': WARN,
+    'arrow-spacing': WARN,
+    'comma-spacing': WARN,
+    'key-spacing': WARN,
+    'object-curly-spacing': [WARN, ALWAYS],
+    'no-trailing-spaces': WARN,
+    'block-spacing': WARN,
+
+    // Smells
+    'no-param-reassign': ERROR,
+    'no-eval': ERROR,
+    'no-extend-native': ERROR,
+    'no-duplicate-imports': ERROR,
+    'no-new-wrappers': ERROR,
+    'no-underscore-dangle': ERROR,
+    'no-var': ERROR,
+    'no-unreachable': ERROR,
+    'no-fallthrough': ERROR,
+    'one-var': [ERROR, NEVER],
+    'no-whitespace-before-property': ERROR,
+
+    // Rules unneeded by us
+    'no-prototype-builtins': OFF
+  }
+}
+
+module.exports = config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spielworksdev/eslint-config",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "ESlint rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hey Markus,
sorry to bother you with this, I'm aware this will not really be possible to review without
trying it out locally.

I did exactly that and it helps using the config in our JS only projects (i.e. not having unfixable errors there
and not having to turn off any rules).

---

Some of the Typescript rules do not work with pure Javascript projects, especially in Node.js.

So the config is now separated into two files, the Typescript config extends from the JS config since the rules still partially apply.

Also removed the "root" property as it's about resolution of config files, not about extending as I thought.

This project itself is still validated using the Typescript config for now to ensure all configs are valid.