### PR TITLE
Adds a rule for trailing commas

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ const config = {
     '@typescript-eslint/naming-convention': [
       WARN,
       { selector: 'enum', format: ['PascalCase'] },
-      { selector: 'enumMember', format: ['UPPER_CASE'] }
-    ]
-  }
+      { selector: 'enumMember', format: ['UPPER_CASE'] },
+    ],
+  },
 }
 
 module.exports = config

--- a/javascript.js
+++ b/javascript.js
@@ -4,6 +4,7 @@ const WARN = 'warn'
 const ERROR = 'error'
 const NEVER = 'never'
 const ALWAYS = 'always'
+const ALWAYS_MULTILINE = 'always-multiline'
 const OFF = 'off'
 
 const config = {
@@ -54,6 +55,9 @@ const config = {
     'no-fallthrough': ERROR,
     'one-var': [ERROR, NEVER],
     'no-whitespace-before-property': ERROR,
+
+    // Trailing commas
+    'comma-dangle': [WARN, ALWAYS_MULTILINE],
 
     // Rules unneeded by us
     'no-prototype-builtins': OFF

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spielworksdev/eslint-config",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "ESlint rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The commit extends the config by adding a new rule for trailing commas after the discussion in 'https://github.com/wombat-tech/wombat-dungeon-master-frontend/pull/964#discussion_r1350176137'.

Was chosen the `always-multiline` option because with this option the rule applies only for values that are added on a new line.

A few examples with chosen configuration:
```
const foo = { bar: 'bar' } <---- Passed
const foo = {
  bar: 'bar' <---- Failed
}
const foo = {
  bar: 'bar', <---- Passed
}
const foo = [0, 1] <---- Passed
const foo = [
  0,
  1 <---- Failed
]
const foo = [
  0,
  1, <---- Passed
]
```

This rule has benefits of using:
1) Fewer diffs in git PRs since you do not need to add commas to lines above; 2) When you add a new line you do not need to think about adding a comma to the line above.

<hr>
A playground with this rule, you can try by yourself. The only change is that there is the `error` option is used, but in our case it's `warn`. I think it's more fair to use `warn` here. 

https://eslint.org/play/#eyJvcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsic291cmNlVHlwZSI6Im1vZHVsZSJ9fSwidGV4dCI6Ii8qZXNsaW50IGNvbW1hLWRhbmdsZTogW1wiZXJyb3JcIiwgXCJhbHdheXMtbXVsdGlsaW5lXCJdKi9cblxudmFyIGZvbyA9IHtcbiAgICBiYXI6IFwiYmF6XCIsXG4gICAgcXV4OiBcInF1dXhcIlxufTtcblxudmFyIGZvbyA9IHsgYmFyOiBcImJhelwiLCBxdXg6IFwicXV1eFwiLCB9O1xuXG52YXIgYXJyID0gWzEsMixdO1xuXG52YXIgYXJyID0gWzEsXG4gICAgMixdO1xuXG52YXIgYXJyID0gW1xuICAgIDEsXG4gICAgMlxuXTtcblxuZm9vKHtcbiAgYmFyOiBcImJhelwiLFxuICBxdXg6IFwicXV1eFwiXG59KTtcbiJ9